### PR TITLE
fix(docker-compose): add extra_hosts for host access and define ac-nework

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,6 @@ services:
             - .env
         networks:
             - local-private-net
-        # allow the container to access the host machine
-        # this is useful for development purposes, e.g. to access the database/AC server running on the host
-        extra_hosts:
-        - "host.docker.internal:host-gateway"
         ports:
             - 48733:48733
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,16 @@ services:
             - .env
         networks:
             - local-private-net
+        # allow the container to access the host machine
+        # this is useful for development purposes, e.g. to access the database/AC server running on the host
+        extra_hosts:
+        - "host.docker.internal:host-gateway"
         ports:
             - 48733:48733
 
 networks:
     local-private-net:
         driver: bridge
+    ac-network:
+        name: ${DOCKER_AC_NETWORK_NAME:-azerothcore-wotlk_ac-network} # default network name if you use the docker setup of ac
+        external: ${DOCKER_AC_NETWORK_EXTERNAL:-false}


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to improve development flexibility by enabling container access to the host machine and adding configuration for an additional network. 

Networking and development improvements:

* Added `extra_hosts` configuration to allow the container to access the host machine, which is useful for development purposes such as accessing services like databases running on the host (`docker-compose.yml`).
* Introduced a new `ac-network` configuration under `networks`, including support for a customizable network name and an option to use an external network (`docker-compose.yml`).